### PR TITLE
Zoom de 14 a 17

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ map.addControl(
         accessToken: mapboxgl.accessToken,
         mapboxgl: mapboxgl,
         placeholder: 'Busca tu casa...',
-        zoom: 14,
+        zoom: 17,
         marker: false,
         language: 'es-ES',
         countries: 'es',


### PR DESCRIPTION
Si buscas toponimos grandes (ciudades, pueblos) se queda a escala grande. Si buscas direcciones, te baja para q puedas ver algo. Creo que es más útil así y que no hace falta más virguería.